### PR TITLE
데이터 흐름 수정

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17_PREVIEW" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
@@ -20,6 +20,7 @@ import androidx.navigation.fragment.findNavController
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.delay
 import kr.co.gamja.study_hub.R
 import kr.co.gamja.study_hub.databinding.FragmentBottomSheetListDialogBinding
 

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
@@ -65,10 +65,8 @@ class ParticipantViewModel : ViewModel() {
                         when(inspection){
                             "STANDBY" -> {
                                 Log.d("ParticipantViewModel", "waiting start ${_participantWaitingList}")
-                                Log.d("ParticipantViewModel", "${ participantWaitingList.value }")
                                 _participantWaitingList.postValue(tmpData)
                                 Log.d("ParticipantViewModel", "waiting fetch ${_participantWaitingList}")
-                                Log.d("ParticipantViewModel", "${ participantWaitingList.value }")
                             }
                             "ACCEPT" -> {
                                 Log.d("ParticipantViewModel", "accept start ${_participantWaitingList.value}")
@@ -98,27 +96,29 @@ class ParticipantViewModel : ViewModel() {
         studyId : Int,
         userId : Int
     ){
-        viewModelScope.launch(Dispatchers.IO){
-            try{
-                val requestDto = ApplyAccpetRequest(
-                    rejectedUserId = userId,
-                    studyId = studyId
-                )
-                val response = AuthRetrofitManager.api.applyAccept(requestDto)
-                if (response.isSuccessful){
-                    if (response.code() != 200) {
-                        when (response.code()) {
-                            401 -> _errMsg.postValue("Unauthorized")
-                            403 -> _errMsg.postValue("Forbidden")
-                            404 -> _errMsg.postValue("Not Found")
+        runBlocking{
+            viewModelScope.launch(Dispatchers.IO){
+                try{
+                    val requestDto = ApplyAccpetRequest(
+                        rejectedUserId = userId,
+                        studyId = studyId
+                    )
+                    val response = AuthRetrofitManager.api.applyAccept(requestDto)
+                    if (response.isSuccessful){
+                        if (response.code() != 200) {
+                            when (response.code()) {
+                                401 -> _errMsg.postValue("Unauthorized")
+                                403 -> _errMsg.postValue("Forbidden")
+                                404 -> _errMsg.postValue("Not Found")
+                            }
                         }
+                    } else {
+                        Log.d("ParticipantViewModel", "response is ${response}")
+                        Log.d("ParticipantViewModel", "Accept is Failed")
                     }
-                } else {
-                    Log.d("ParticipantViewModel", "response is ${response}")
-                    Log.d("ParticipantViewModel", "Accept is Failed")
+                } catch (e: Exception){
+                    throw IllegalArgumentException(e)
                 }
-            } catch (e: Exception){
-                throw IllegalArgumentException(e)
             }
         }
     }
@@ -129,27 +129,30 @@ class ParticipantViewModel : ViewModel() {
         studyId : Int,
         userId : Int
     ){
-        viewModelScope.launch(Dispatchers.IO){
-            try {
-                val requestDto = ApplyRejectDto(
-                    rejectReason = rejectReason,
-                    rejectedUserId = userId,
-                    studyId = studyId
-                )
-                val response = AuthRetrofitManager.api.applyReject(requestDto)
-                if (response.isSuccessful){
-                    if (response.code() != 200) {
-                        when (response.code()) {
-                            401 -> _errMsg.postValue("Unauthorized")
-                            403 -> _errMsg.postValue("Forbidden")
-                            404 -> _errMsg.postValue("Not Found")
+        runBlocking{
+            viewModelScope.launch(Dispatchers.IO){
+                try {
+                    val requestDto = ApplyRejectDto(
+                        rejectReason = rejectReason,
+                        rejectedUserId = userId,
+                        studyId = studyId
+                    )
+
+                    val response = AuthRetrofitManager.api.applyReject(requestDto)
+                    if (response.isSuccessful){
+                        if (response.code() != 200) {
+                            when (response.code()) {
+                                401 -> _errMsg.postValue("Unauthorized")
+                                403 -> _errMsg.postValue("Forbidden")
+                                404 -> _errMsg.postValue("Not Found")
+                            }
                         }
+                    } else {
+                        Log.d("ParticipantViewModel", "Refusal is Failed")
                     }
-                } else {
-                    Log.d("ParticipantViewModel", "Refusal is Failed")
+                } catch (e : Exception) {
+                    throw IllegalArgumentException(e)
                 }
-            } catch (e : Exception) {
-                throw IllegalArgumentException(e)
             }
         }
     }


### PR DESCRIPTION
## Waiting ViewModel
기존에 ViewModel에서 viewModelScope.launch를 통해서 reject 혹은 accept 를 수행하게 되었는데, 이 과정에서 reject혹은 accept한 후에는 fetchData가 수반되는 흐름이 문제가 되었습니다.
fetchData에서는 runBlocking이 처리 되어 있는데, reject , accept coroutine job을 처리하기 전에 fetchData job이 실행되게 되며, 이 때 fetchData 에서 runBlocking이 걸리므로 accept나 reject에서 coroutine job이 cancellation되는 오류가 발생한 것입니다.

따라서 accept와 reject에서 runBlocking을 걸어 작업이 끝난 뒤에 다른 작업이 실행될 수 있도록 해뒀습니다.
혹시 데이터 흐름을 조금 더 유기적으로 바꾼다고 하신다면 withContext나 다른 job scheduling 함수들을 사용해서 바꾸시면 됩니다!