### PR TITLE
Search Flow 수정 및 오류 수정

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17_PREVIEW" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/kr/co/gamja/study_hub/data/model/ApplyAccpetRequest.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/model/ApplyAccpetRequest.kt
@@ -1,6 +1,6 @@
 package kr.co.gamja.study_hub.data.model
 
-data class ApplyAccpetRequest(
+data class ApplyAcceptRequest(
     val rejectedUserId : Int,
     val studyId : Int
 )

--- a/app/src/main/java/kr/co/gamja/study_hub/data/model/CommonApplyDataResponse.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/model/CommonApplyDataResponse.kt
@@ -1,0 +1,6 @@
+package kr.co.gamja.study_hub.data.model
+
+data class CommonApplyDataResponse(
+    val status : String,
+    val message : String
+)

--- a/app/src/main/java/kr/co/gamja/study_hub/data/model/SearchRecommendResponseDto.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/model/SearchRecommendResponseDto.kt
@@ -1,0 +1,5 @@
+package kr.co.gamja.study_hub.data.model
+
+data class SearchRecommendResponseDto(
+    val recommendList: List<String>
+)

--- a/app/src/main/java/kr/co/gamja/study_hub/data/repository/AuthRetrofitManager.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/repository/AuthRetrofitManager.kt
@@ -1,6 +1,7 @@
 package kr.co.gamja.study_hub.data.repository
 
 import com.google.gson.GsonBuilder
+import kr.co.gamja.study_hub.global.NullOnEmptyConverterFactory
 import okhttp3.Dispatcher
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -16,6 +17,7 @@ object AuthRetrofitManager {
     val retrofit = Retrofit.Builder()
         .baseUrl(BASE_URL)
         .client(createClientAuth())
+        .addConverterFactory(NullOnEmptyConverterFactory())
         .addConverterFactory(GsonConverterFactory.create(gson))
         .build()
 

--- a/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
@@ -26,7 +26,7 @@ interface StudyHubApi {
     //스터디 참여 신청 정보 수락
     @PUT("/api/v1/study-accept")
     suspend fun applyAccept(
-        @Body dto : ApplyAccpetRequest
+        @Body dto : ApplyAcceptRequest
     ) : Response<Any>
 
 

--- a/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
@@ -27,14 +27,14 @@ interface StudyHubApi {
     @PUT("/api/v1/study-accept")
     suspend fun applyAccept(
         @Body dto : ApplyAccpetRequest
-    ) : Response<Unit>
+    ) : Response<Any>
 
 
     //스터디 참여 신청 정보 거절
     @PUT("/api/v1/study-reject")
     suspend fun applyReject(
         @Body dto : ApplyRejectDto
-    ) : Response<Unit>
+    ) : Response<Any>
 
     //스터디 참여 신청 정보
     @GET("/api/v2/study")

--- a/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/data/repository/StudyHubApi.kt
@@ -45,6 +45,15 @@ interface StudyHubApi {
         @Query("studyId") studyId : Int?,
     ) : Response<GetRegisterListDto>
 
+    //스터디 참여 신청 정보 (거절)
+    @GET("/api/v3/study")
+    suspend fun getRegisterListReject(
+        @Query("inspection") inspection : String = "REJECT",
+        @Query("page") page : Int,
+        @Query("size") size : Int = 10,
+        @Query("studyId") studyId : Int
+    ) : Response<GetRegisterListDto>
+
     //스터디 참여 신청 정보 조회
     @GET("/api/v1/study-request")
     suspend fun getStudyApplyInfo(
@@ -126,6 +135,9 @@ interface StudyHubApi {
     // 스터디 수정
     @PUT("/api/v1/study-posts")
     suspend fun correctMyStudy(@Body correctStudyRequest: CorrectStudyRequest): Response<Int>
+
+    @GET("/api/v1/study-post/recommend")
+    suspend fun getSearchRecommends(@Query("keyword") keyword : String) : Response<SearchRecommendResponseDto>
 
     // 스터디 생성
     @POST("/api/v1/study-posts")
@@ -243,7 +255,7 @@ interface StudyHubApi {
     @GET("/api/v1/study-request")
     suspend fun getUserApplyHistory(@Query("page") page: Int, @Query("size") size: Int) : Response<ApplicationHistoryResponse>
 
-//    reject controller
+    //reject controller
     // 단일 거절 이유 보기
     @GET("/api/v1/reject")
     suspend fun getDenyReason(@Query("studyId") studyId: Int) : Response<CheckDenyReasonResponse>

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/RecommendItemAdapter.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/RecommendItemAdapter.kt
@@ -1,0 +1,50 @@
+package kr.co.gamja.study_hub.feature.home.search
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.co.gamja.study_hub.databinding.SearchRecommendItemBinding
+
+class RecommendItemAdapter : RecyclerView.Adapter<RecommendItemAdapter.RecommendViewHolder>(){
+
+    private lateinit var listener : OnRecommendClick
+    private val recommendList = mutableListOf<String>()
+
+    fun setOnClickListener(listener : OnRecommendClick) {
+        this.listener = listener
+    }
+
+    interface OnRecommendClick {
+        fun onClick(value : String)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecommendViewHolder {
+        val binding = SearchRecommendItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return RecommendViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: RecommendViewHolder, position: Int) {
+        holder.bind(recommendList[position])
+    }
+
+    override fun getItemCount(): Int = recommendList.size
+
+    fun submitList(list : List<String>) {
+        recommendList.clear()
+        recommendList.addAll(list)
+        notifyDataSetChanged()
+    }
+
+    inner class RecommendViewHolder(
+        val binding : SearchRecommendItemBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(recommend : String) {
+            binding.tvRecommend.text = recommend
+            binding.lyRecommend.setOnClickListener{
+                listener.onClick(recommend)
+            }
+        }
+
+    }
+}

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/RecommendViewModel.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/RecommendViewModel.kt
@@ -1,0 +1,47 @@
+package kr.co.gamja.study_hub.feature.home.search
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kr.co.gamja.study_hub.data.model.SearchRecommendResponseDto
+import kr.co.gamja.study_hub.data.repository.RetrofitManager
+
+class RecommendViewModel : ViewModel() {
+    
+    /** recommned api를 사용해서 recommendList 생성 */
+    private val _recommendList = MutableLiveData<List<String>>()
+    val recommendList : LiveData<List<String>>
+        get() = _recommendList
+
+    //키워드 기반 recommendList 업데이트
+    fun searchRecommend(keyword : String) {
+        runBlocking{
+            viewModelScope.launch{
+                val response = RetrofitManager.api.getSearchRecommends(keyword)
+                try {
+                    if (response.isSuccessful){
+                        val result = response.body() ?: SearchRecommendResponseDto(emptyList())
+
+                        if (result.recommendList.isNotEmpty()){
+                            _recommendList.postValue(result.recommendList)
+                        }
+
+                    } else {
+                        Log.e("Error", "Response is Failed\n${response.errorBody()}")
+                    }
+                } catch (e : Exception) {
+                    throw IllegalArgumentException(e.message)
+                }
+            }
+
+        }
+    }
+
+    fun resetList() {
+        _recommendList.postValue(emptyList())
+    }
+}

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchItemAdapter.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchItemAdapter.kt
@@ -41,7 +41,6 @@ class SearchItemAdapter(private val context : Context) :
         holder: SearchItemViewHolder,
         position: Int
     ) {
-        Log.d("Adapter","itemlist : ${contentList}")
         holder.bind(contentList[position])
     }
 

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchViewModel.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchViewModel.kt
@@ -15,12 +15,13 @@ import kr.co.gamja.study_hub.data.repository.RetrofitManager
 class SearchViewModel: ViewModel() {
 
     val tag = this.javaClass.simpleName
-    // editText 입력 단어 - 통신 보낼 변수
+
+    //검색된 내용
+    private var keyword = ""
 
     // 둘러보기인지
     var isUserLogin = MutableLiveData<Boolean>(true)
 
-    val searchWord = MutableLiveData<String>()
     private val _searchImg =MutableLiveData<Boolean>(true)
     val searchImg:LiveData<Boolean> get() =_searchImg
 
@@ -31,11 +32,11 @@ class SearchViewModel: ViewModel() {
 
     // 텍스트 지우기 검색 이미지 활성화
     fun updateSearchImg(){
-        _searchImg.value = searchWord.value.toString().isEmpty()
+        _searchImg.value = keyword == ""
     }
 
     // 단어를 가지고 검색
-    fun fetchStudys(searchContent: String, isHot : Boolean, isDepartment: Boolean){
+    fun fetchStudys(isHot : Boolean, isDepartment: Boolean){
         runBlocking{
             viewModelScope.launch(Dispatchers.IO) {
                 try {
@@ -43,7 +44,7 @@ class SearchViewModel: ViewModel() {
                         hot = isHot,
                         page = 0,
                         size = 10,
-                        inquiryText = searchContent,
+                        inquiryText = keyword,
                         titleAndMajor = !isDepartment
                     )
                     if (response.isSuccessful){
@@ -61,12 +62,8 @@ class SearchViewModel: ViewModel() {
         }
     }
 
-    fun resetList() {
-        _studys.postValue(listOf())
-    }
-
     //데이터 추가
-    suspend fun addSearchData(isHot : Boolean, searchContent: String, isDepartment: Boolean, page : Int) =
+    suspend fun addSearchData(isHot : Boolean, isDepartment: Boolean, page : Int) =
         viewModelScope.async(Dispatchers.IO) {
 
             Log.d(tag,"addSearchData : ${_studys.value}")
@@ -75,8 +72,8 @@ class SearchViewModel: ViewModel() {
                 val response = RetrofitManager.api.getStudyPostAll(
                     hot = isHot,
                     page = page,
-                    size = 8,
-                    inquiryText = searchContent,
+                    size = 10,
+                    inquiryText = keyword,
                     titleAndMajor = !isDepartment
                 )
 
@@ -95,4 +92,12 @@ class SearchViewModel: ViewModel() {
                 return@async e.message
             }
         }.await()
+
+    //검색어 저장
+    fun saveKeyword(keyword : String) {
+        this.keyword = keyword
+    }
+
+    //검색어 불러오기
+    fun getKeyword() = keyword
 }

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchingFragment.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/home/search/SearchingFragment.kt
@@ -1,0 +1,143 @@
+package kr.co.gamja.study_hub.feature.home.search
+
+import android.content.Context
+import android.os.Bundle
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.KeyEvent
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.view.inputmethod.InputMethodManager
+import android.widget.EditText
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat.getSystemService
+import androidx.databinding.DataBindingUtil
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.LinearLayoutManager
+import kr.co.gamja.study_hub.R
+import kr.co.gamja.study_hub.databinding.FragmentSearchingBinding
+import kr.co.gamja.study_hub.global.ExtensionFragment.Companion.hideKeyboard
+import kr.co.gamja.study_hub.global.RcvDecoration
+
+class SearchingFragment : Fragment() {
+
+    private lateinit var binding : FragmentSearchingBinding
+    private val viewModel : RecommendViewModel by viewModels()
+    private lateinit var adapter : RecommendItemAdapter
+    private var lastLength = 0
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = DataBindingUtil.inflate(layoutInflater, R.layout.fragment_searching, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        initRcv()
+
+        binding.apply{
+
+            val beforeKeyword = arguments?.getString("beforeKeyword")
+            if(beforeKeyword != null) {
+                editSearch.setText(beforeKeyword)
+            }
+
+            keyword = editSearch.text.toString()
+
+            isEnabled = false
+
+            //observer 설정
+            viewModel.recommendList.observe(viewLifecycleOwner, Observer{
+                adapter.submitList(it)
+            })
+
+            // 툴바 설정
+            val toolbar = searchMainToolbar
+            (requireActivity() as AppCompatActivity).setSupportActionBar(toolbar)
+            (requireActivity() as AppCompatActivity).supportActionBar?.title = ""
+
+            // editText 검색어 지우기
+            binding.btnTextDelete.setOnClickListener {
+                binding.editSearch.text.clear()
+                viewModel.resetList()
+            }
+
+            //검색 내용 변화 event
+            binding.editSearch.addTextChangedListener (object: TextWatcher {
+                override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+                }
+                override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                    if (!s.isNullOrEmpty()){
+                        if (s.length > lastLength){
+                            viewModel.searchRecommend(s.toString())
+                        } else {
+                            viewModel.resetList()
+                        }
+                        isEnabled = false
+                    } else {
+                        isEnabled = true
+                    }
+                    lastLength = s?.length ?: 0
+                }
+                override fun afterTextChanged(s: Editable?) {
+                }
+            })
+
+            //ime action (search) event
+            editSearch.setOnEditorActionListener { v, actionId, event ->
+                if (actionId == EditorInfo.IME_ACTION_SEARCH || event.keyCode == KeyEvent.KEYCODE_ENTER){
+                    viewModel.searchRecommend(editSearch.text.toString())
+                    return@setOnEditorActionListener true
+                }
+                false
+            }
+
+            //recyclerView를 눌러도 keyboard를 숨길 수 있도록
+            rcvSearchResult.setOnTouchListener { v, event ->
+                if (event.action == MotionEvent.ACTION_DOWN) {
+                    hideKeyboard()
+                }
+                false
+            }
+        }
+    }
+
+    //recycler view 초기화
+    private fun initRcv(){
+        binding.apply{
+
+            adapter = RecommendItemAdapter()
+            val listener = object : RecommendItemAdapter.OnRecommendClick{
+                override fun onClick(value : String) {
+                    // SearchFragment로 이동
+                    // argument에 value를 전달
+                    val bundle = Bundle()
+                    bundle.putString("keyword", value)
+                    arguments = bundle
+                    findNavController().navigate(
+                        R.id.action_search_recommend_to_search_main,
+                        arguments
+                    )
+                }
+            }
+            adapter.setOnClickListener(listener)
+
+            rcvSearchResult.adapter = adapter
+            rcvSearchResult.layoutManager = LinearLayoutManager(requireContext())
+
+            val itemSpace = resources.getDimensionPixelSize(R.dimen.eight)
+            val deco = RcvDecoration(itemSpace)
+            rcvSearchResult.addItemDecoration(deco)
+        }
+    }
+}

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
@@ -21,6 +21,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 import kr.co.gamja.study_hub.R
 import kr.co.gamja.study_hub.databinding.FragmentBottomSheetListDialogBinding
 
@@ -103,24 +104,18 @@ class BottomSheet() : BottomSheetDialogFragment() {
                         R.id.action_participantFragment_to_refusalReasonFragment,
                         arguments
                     )
-                    viewModel.fetchData("STANDBY", studyId, page)
                     dismiss()
                 } else {
                     if (userId != -1 &&  studyId != -1 && page != -1){
 
                         Log.d("Participant", "userId = ${userId} studyId = ${studyId}")
 
-                        //거절 api 사용
-                        viewModel.reject(
-                            rejectReason = selectedReason,
-                            studyId = studyId,
-                            userId = userId
-                        )
-
-                        Log.d("Paricipant BottomSheet", "fetchData start")
-                        viewModel.fetchData("STANDBY", studyId, page)
-                        Log.d("Participant BottomSheet", "fetchData done")
-
+//                        //거절 api 사용
+//                        viewModel.reject(
+//                            rejectReason = selectedReason,
+//                            studyId = studyId,
+//                            userId = userId
+//                        )
                         //dialog 띄우기
                         val customToast = CustomToast()
                         val bundle = Bundle()

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/BottomSheet.kt
@@ -110,12 +110,12 @@ class BottomSheet() : BottomSheetDialogFragment() {
 
                         Log.d("Participant", "userId = ${userId} studyId = ${studyId}")
 
-//                        //거절 api 사용
-//                        viewModel.reject(
-//                            rejectReason = selectedReason,
-//                            studyId = studyId,
-//                            userId = userId
-//                        )
+                        //거절 api 사용
+                        viewModel.reject(
+                            rejectReason = selectedReason,
+                            studyId = studyId,
+                            userId = userId
+                        )
                         //dialog 띄우기
                         val customToast = CustomToast()
                         val bundle = Bundle()

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
@@ -44,13 +44,11 @@ class ParticipantViewModel : ViewModel() {
         studyId : Int,
         page : Int,
     ) {
-        Log.d("Participant", "study id : ${studyId}")
         runBlocking{
             viewModelScope.launch(Dispatchers.IO){
                 //신청 리스트 받아오기
                 try {
                     val response = RetrofitManager.api.getRegisterList(inspection, page, 8, studyId)
-                    Log.d("Participant", "${ response.body() }")
                     if (response.isSuccessful){
                         val result = response.body() ?: throw NullPointerException("Result is NULL")
                         val datas = result.applyUserData.content
@@ -60,27 +58,17 @@ class ParticipantViewModel : ViewModel() {
                         datas.forEach{ data ->
                             tmpData.add(data)
                         }
-                        Log.d("ParticipantViewModel", "fetch data ~ing")
-                        Log.d("ParticipantViewModel", "new data : ${tmpData}")
                         when(inspection){
                             "STANDBY" -> {
-                                Log.d("ParticipantViewModel", "waiting start ${_participantWaitingList}")
                                 _participantWaitingList.postValue(tmpData)
-                                Log.d("ParticipantViewModel", "waiting fetch ${_participantWaitingList}")
                             }
                             "ACCEPT" -> {
-                                Log.d("ParticipantViewModel", "accept start ${_participantWaitingList.value}")
                                 _acceptList.postValue(tmpData)
-                                Log.d("ParticipantViewModel", "accept fetch ${_participantWaitingList.value}")
                             }
                             "REJECT" -> {
-                                Log.d("ParticipantViewModel", "reject start ${_participantWaitingList.value}")
                                 _refuseList.postValue(tmpData)
-                                Log.d("ParticipantViewModel", "reject fetch ${_participantWaitingList.value}")
                             }
                         }
-
-                        Log.d("ParticipantViewModel", "fetchWaitingList is Success")
                     } else {
                         Log.d("ParticipantViewModel", "fetchWaitingList is Failed")
                     }

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/ParticipantViewModel.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
-import kr.co.gamja.study_hub.data.model.ApplyAccpetRequest
+import kr.co.gamja.study_hub.data.model.ApplyAcceptRequest
 import kr.co.gamja.study_hub.data.model.ApplyRejectDto
 import kr.co.gamja.study_hub.data.model.RegisterListContent
 import kr.co.gamja.study_hub.data.repository.AuthRetrofitManager
@@ -91,7 +91,7 @@ class ParticipantViewModel : ViewModel() {
     ){
         viewModelScope.launch(Dispatchers.IO){
             try{
-                val requestDto = ApplyAccpetRequest(
+                val requestDto = ApplyAcceptRequest(
                     rejectedUserId = userId,
                     studyId = studyId
                 )

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/RefusalReasonFragment.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/RefusalReasonFragment.kt
@@ -82,7 +82,7 @@ class RefusalReasonFragment : Fragment() {
                 bundle.putInt("studyId", studyId)
                 arguments = bundle
                 findNavController().navigate(
-                    R.id.action_refusalReasonFragment_to_participantFragment,
+                    R.id.action_global_to_participantFragment,
                     arguments
                 )
             }

--- a/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/waiting/WaitingFragment.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/feature/mypage/participant/waiting/WaitingFragment.kt
@@ -39,9 +39,14 @@ class WaitingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+
         val studyId = arguments?.getInt("studyId") ?: -1
 
         initRecyclerView(studyId)
+
+        if (studyId != -1) {
+            viewModel.fetchData(inspection = "STANDBY", studyId = studyId, page = page)
+        }
 
         //observing
         viewModel.participantWaitingList.observe(viewLifecycleOwner, Observer{
@@ -56,8 +61,6 @@ class WaitingFragment : Fragment() {
                 binding.rcvContent.visibility = View.VISIBLE
             }
         })
-
-        viewModel.fetchData("STANDBY", studyId, page)
     }
 
     //RecyclerView 초기화

--- a/app/src/main/java/kr/co/gamja/study_hub/global/NullOnEmptyConverterFactory.kt
+++ b/app/src/main/java/kr/co/gamja/study_hub/global/NullOnEmptyConverterFactory.kt
@@ -1,0 +1,18 @@
+package kr.co.gamja.study_hub.global
+
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+import java.lang.reflect.Type
+
+class NullOnEmptyConverterFactory : Converter.Factory() {
+    override fun responseBodyConverter(
+        type: Type,
+        annotations: Array<out Annotation>,
+        retrofit: Retrofit
+    ): Converter<ResponseBody, *> {
+        val delegate : Converter<ResponseBody, *> =
+            retrofit.nextResponseBodyConverter<Any>(this, type, annotations)
+        return Converter {body -> if (body.contentLength() == 0L) null else delegate.convert(body)}
+    }
+}

--- a/app/src/main/res/drawable/icon_search_s_gray.xml
+++ b/app/src/main/res/drawable/icon_search_s_gray.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M16.72,11.61C16.72,8.79 14.42,6.49 11.6,6.49C8.78,6.49 6.49,8.77 6.49,11.6C6.49,14.43 8.78,16.73 11.6,16.73C14.42,16.73 16.72,14.43 16.72,11.61ZM5,11.6C5,7.96 7.96,5 11.6,5C15.25,5 18.2,7.96 18.2,11.6C18.2,13.046 17.733,14.385 16.941,15.473L20.001,18.533L18.947,19.586L15.935,16.574C14.774,17.586 13.258,18.2 11.6,18.2C7.96,18.2 5,15.24 5,11.6Z"
+      android:fillColor="#C2C8CC"
+      android:fillType="evenOdd"/>
+</vector>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -22,6 +22,9 @@
         <variable
             name="cntItem"
             type="String"/>
+        <variable
+            name="keyword"
+            type="String" />
         <import type="android.view.View" />
     </data>
 
@@ -77,22 +80,11 @@
             android:paddingTop="13dp"
             android:paddingRight="14dp"
             android:paddingBottom="13dp"
-            android:text="@={viewModel.searchWord}"
+            android:text="@={keyword}"
             android:textColor="@color/sysblack1"
             android:textColorHint="@color/BG_70"
             android:textSize="16sp"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/searchMain_toolbar" />
-
-        <ImageView
-            android:id="@+id/icon_search"
-            android:layout_width="@dimen/twenty_four"
-            android:layout_height="@dimen/twenty_four"
-            android:layout_marginTop="29dp"
-            android:layout_marginEnd="@dimen/fourteen"
-            android:src="@drawable/icon_search_l_black"
-            android:visibility="@{viewModel.searchImg?View.VISIBLE:View.GONE}"
-            app:layout_constraintRight_toRightOf="@+id/edit_search"
             app:layout_constraintTop_toBottomOf="@+id/searchMain_toolbar" />
 
         <androidx.appcompat.widget.AppCompatButton

--- a/app/src/main/res/layout/fragment_searching.xml
+++ b/app/src/main/res/layout/fragment_searching.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <data>
+        <variable
+            name="isEnabled"
+            type="Boolean"/>
+        <variable
+            name="keyword"
+            type="String" />
+        <import type="android.view.View"/>
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/searchingFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/syswhite"
+        android:focusable="true"
+        android:focusableInTouchMode="true">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/searchMain_toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:layout_alignParentTop="true"
+            android:background="@color/sysblack2"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <RelativeLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginEnd="20dp">
+
+                <ImageButton
+                    android:id="@+id/icon_back"
+                    android:layout_width="@dimen/resized_item"
+                    android:layout_height="@dimen/resized_item"
+                    android:layout_alignParentStart="true"
+                    android:background="@drawable/icon_arrow_left_l_white" />
+
+                <ImageButton
+                    android:id="@+id/icon_bookmark"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentEnd="true"
+                    android:background="@drawable/baseline_bookmark_border_24_ffffff" />
+
+            </RelativeLayout>
+        </androidx.appcompat.widget.Toolbar>
+
+        <AutoCompleteTextView
+            android:id="@+id/edit_search"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginHorizontal="@dimen/twenty"
+            android:layout_marginTop="@dimen/sixteen"
+            android:background="@drawable/btn_background_search"
+            android:completionThreshold="1"
+            android:hint="@string/btn_searchBar"
+            android:imeOptions="actionSearch"
+            android:inputType="text"
+            android:paddingLeft="14dp"
+            android:paddingTop="13dp"
+            android:paddingRight="14dp"
+            android:paddingBottom="13dp"
+            android:text="@={keyword}"
+            android:textColor="@color/sysblack1"
+            android:textColorHint="@color/BG_70"
+            android:textSize="16sp"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/searchMain_toolbar" />
+
+        <ImageView
+            android:id="@+id/icon_search"
+            android:layout_width="@dimen/twenty_four"
+            android:layout_height="@dimen/twenty_four"
+            android:layout_marginTop="29dp"
+            android:layout_marginEnd="@dimen/fourteen"
+            android:src="@drawable/icon_search_l_black"
+            android:visibility="@{isEnabled? View.VISIBLE : View.GONE}"
+            app:layout_constraintRight_toRightOf="@+id/edit_search"
+            app:layout_constraintTop_toBottomOf="@+id/searchMain_toolbar" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/btn_textDelete"
+            android:layout_width="@dimen/twenty_four"
+            android:layout_height="@dimen/twenty_four"
+            android:layout_marginTop="29dp"
+            android:layout_marginEnd="@dimen/fourteen"
+            android:background="@drawable/icon_circle_delete_bright"
+            android:visibility="@{isEnabled? View.GONE : View.VISIBLE}"
+            app:layout_constraintRight_toRightOf="@+id/edit_search"
+            app:layout_constraintTop_toBottomOf="@+id/searchMain_toolbar" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rcv_search_result"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="12dp"
+            android:layout_marginBottom="40dp"
+            android:paddingHorizontal="20dp"
+            android:background="@color/syswhite"
+            app:layout_constrainedHeight="true"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/edit_search"
+            app:layout_constraintBottom_toBottomOf="parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/app/src/main/res/layout/search_recommend_item.xml
+++ b/app/src/main/res/layout/search_recommend_item.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/lyRecommend"
+    android:layout_width="match_parent"
+    android:layout_height="48dp"
+    android:background="@color/syswhite"
+    android:orientation="horizontal"
+    android:paddingVertical="12dp"
+    android:paddingStart="8dp"
+    android:gravity="center_vertical">
+
+    <ImageView
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        app:srcCompat="@drawable/icon_search_s_gray"
+        android:layout_marginEnd="8dp"/>
+
+    <TextView
+        android:id="@+id/tvRecommend"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:text=""
+        android:textSize="14sp"
+        android:textColor="@color/sysblack1"
+        tools:text="디자인학부"/>
+
+</LinearLayout>

--- a/app/src/main/res/navigation/nav_graph_from_home.xml
+++ b/app/src/main/res/navigation/nav_graph_from_home.xml
@@ -463,4 +463,7 @@
     <action
         android:id="@+id/action_global_checkRefusalReasonFragment"
         app:destination="@id/checkRefusalReasonFragment" />
+    <action
+        android:id="@+id/action_global_to_participantFragment"
+        app:destination="@+id/participantFragment"/>
 </navigation>

--- a/app/src/main/res/navigation/nav_graph_from_home.xml
+++ b/app/src/main/res/navigation/nav_graph_from_home.xml
@@ -16,7 +16,7 @@
             android:defaultValue="true" />
         <action
             android:id="@+id/action_mainFragment01_to_mainFragment02"
-            app:destination="@id/searchFragment" />
+            app:destination="@id/searchRecommendFragment" />
         <action
             android:id="@+id/action_mainFragment01_to_mainFragment03"
             app:destination="@id/manualFragment" />
@@ -36,6 +36,15 @@
 
     <!-- Search page -->
     <fragment
+        android:id="@+id/searchRecommendFragment"
+        android:name="kr.co.gamja.study_hub.feature.home.search.SearchingFragment"
+        android:label="fragment_search_recommend"
+        tools:layout="@layout/fragment_searching">
+        <action
+            android:id="@+id/action_search_recommend_to_search_main"
+            app:destination="@+id/searchFragment"/>
+    </fragment>
+    <fragment
         android:id="@+id/searchFragment"
         android:name="kr.co.gamja.study_hub.feature.home.search.SearchFragment"
         android:label="fragment_main02"
@@ -46,6 +55,9 @@
         <action
             android:id="@+id/action_search_to_content"
             app:destination="@+id/studyContentFragment" />
+        <action
+            android:id="@+id/action_search_to_search_recommend"
+            app:destination="@+id/searchRecommendFragment"/>
     </fragment>
 
     <!-- login page -->
@@ -143,13 +155,12 @@
         <action
             android:id="@+id/action_participantFragment_to_refusalReasonFragment"
             app:destination="@+id/refusalReasonFragment" />
-
     </fragment>
     <fragment
         android:id="@+id/waitingFragment"
         android:name="kr.co.gamja.study_hub.feature.mypage.participant.waiting.WaitingFragment"
         android:label="fragment_waiting"
-        tools:layout="@layout/fragment_waiting"></fragment>
+        tools:layout="@layout/fragment_waiting"/>
     <fragment
         android:id="@+id/participationFragment"
         android:name="kr.co.gamja.study_hub.feature.mypage.participant.participation.ParticipationFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,10 +244,10 @@
     <string name="rejectReason">거절 이유 확인하기</string>
     <string name="deleteApplyHistory_sub">삭제하면 신청이 취소돼요</string>
 
-<!--    거절이유확인-->
+    <!--    거절이유확인-->
     <string name="txt_reasonForRefusal">스터디 팀장의 거절 이유예요🥲</string>
-    
-<!--    참여한스터디-->
+
+    <!--    참여한스터디-->
     <string name="deleteEngagedStudy_title">이 스터디를 삭제할까요?</string>
     <string name="deleteEngagedStudy_sub">삭제하면 채팅방을 다시 찾을 수 없어요</string>
 


### PR DESCRIPTION
## Search 화면 흐름 수정
기존 SearchFragment에서 데이터를 받아 실시간으로 검색 결과를 업데이트
->
SearingFragment에서 데이터를 받아서 추천 검색어 API를 통해 받아온 데이터 (최대 10개)를 검색어 목록으로 띄우고 이를 선택 시 SearchFragment로 이동하여 결과를 보여줍니다

이 때 SearchFragment에서 EditText 선택 시 SearchingFragment로 돌아가도록 합니다

## Reject API 사용 시 앱 다운되는 버그 수정
fetch, rejec,t accept 등 api를 사용할 때 RunBlocking 함수 시행 중 Dismiss되는 Dialog로 인해 발생했던 것으로 예상하여 흐름을 수정했습니다.